### PR TITLE
Add Kubecost to exporter list

### DIFF
--- a/api/exporter_list.csv
+++ b/api/exporter_list.csv
@@ -35,3 +35,4 @@ Python Client Library,https://github.com/prometheus/client_python,1,Library
 Ruby Client Library,https://github.com/prometheus/client_ruby,1,Library
 Push Gateway,https://github.com/prometheus/pushgateway,1,Monitoring
 k8s-image-availability-exporter,https://github.com/flant/k8s-image-availability-exporter,0,Miscellaneous
+Kubecost,https://github.com/kubecost/cost-model,0,Miscellaneous

--- a/api/repo_list.txt
+++ b/api/repo_list.txt
@@ -34,3 +34,4 @@
 "https://github.com/prometheus/client_python",
 "https://github.com/prometheus/client_ruby",
 "https://github.com/prometheus/pushgateway",
+"https://github.com/kubecost/cost-model",


### PR DESCRIPTION
Kubecost is a Prometheus exporter, but can be deployed as
exclusively an exporter (without consuming from Prometheus)
with these instructions:

https://github.com/kubecost/cost-model/blob/develop/kubecost-exporter.md

If you'd prefer to link directly to that doc, I'm happy to make whatever changes are required to this PR.