### PR TITLE
add Elasticsearch Exporter in exporter_list.csv

### DIFF
--- a/api/exporter_list.csv
+++ b/api/exporter_list.csv
@@ -38,3 +38,4 @@ k8s image availability,k8s-image-availability-exporter,https://github.com/flant/
 Kubecost,Kubecost,https://github.com/kubecost/cost-model,0,Miscellaneous
 dnsbl-exporter,dnsbl-exporter,https://github.com/Luzilla/dnsbl_exporter,0,Monitoring
 Query exporter,query-exporter,https://github.com/go-gywn/query-exporter,0,Database
+Elasticsearch Exporter,Elasticsearch Exporter,https://github.com/prometheus-community/elasticsearch_exporter,0,Database


### PR DESCRIPTION
- adding elasticsearch-exporter to exporter_list.csv
- [Elasticsearch Exporter](https://github.com/prometheus-community/elasticsearch_exporter)