### PR TITLE
add Prometheus Node Exporter helm chart contents

### DIFF
--- a/contents/Node-Exporter/helm-chart/Chart.yaml
+++ b/contents/Node-Exporter/helm-chart/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+appVersion: 1.0.1
+# The prometheus-node-exporter chart is deprecated and no longer maintained. For details deprecation,
+# including how to un-deprecate a chart see the PROCESSES.md file.
+deprecated: true
+description: DEPRECATED A Helm chart for prometheus node-exporter
+name: prometheus-node-exporter
+version: 1.11.2
+home: https://github.com/prometheus/node_exporter/
+sources:
+- https://github.com/prometheus/node_exporter/
+keywords:
+- node-exporter
+- prometheus
+- exporter

--- a/contents/Node-Exporter/helm-chart/README.md
+++ b/contents/Node-Exporter/helm-chart/README.md
@@ -1,0 +1,92 @@
+# Prometheus Node Exporter
+
+DEPRECATED and moved to <https://github.com/prometheus-community/helm-charts>
+
+* Installs prometheus [node exporter](https://github.com/prometheus/node_exporter)
+
+## TL;DR;
+
+```console
+$ helm install stable/prometheus-node-exporter
+```
+
+## Introduction
+
+This chart bootstraps a prometheus [node exporter](http://github.com/prometheus/node_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release stable/prometheus-node-exporter
+```
+
+The command deploys node exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Node Exporter chart and their default values.
+
+|             Parameter                 |                                                          Description                                                          |                 Default                          |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `image.repository`                    | Image repository                                                                                                              | `quay.io/prometheus/node-exporter`               |
+| `image.tag`                           | Image tag                                                                                                                     | `v1.0.1`                                         |
+| `image.pullPolicy`                    | Image pull policy                                                                                                             | `IfNotPresent`                                   |
+| `extraArgs`                           | Additional container arguments                                                                                                | `[]`                                             |
+| `extraHostVolumeMounts`               | Additional host volume mounts                                                                                                 | `[]`                                             |
+| `podAnnotations`                      | Annotations to be added to node exporter pods                                                                                 | `{}`                                             |
+| `podLabels`                           | Additional labels to be added to pods                                                                                         | `{}`                                             |
+| `rbac.create`                         | If true, create & use RBAC resources                                                                                          | `true`                                           |
+| `rbac.pspEnabled`                     | Specifies whether a PodSecurityPolicy should be created.                                                                      | `true`                                           |
+| `resources`                           | CPU/Memory resource requests/limits                                                                                           | `{}`                                             |
+| `service.type`                        | Service type                                                                                                                  | `ClusterIP`                                      |
+| `service.port`                        | The service port                                                                                                              | `9100`                                           |
+| `service.targetPort`                  | The target port of the container                                                                                              | `9100`                                           |
+| `service.nodePort`                    | The node port of the service                                                                                                  |                                                  |
+| `service.listenOnAllInterfaces`       | If true, listen on all interfaces using IP `0.0.0.0`. Else listen on the IP address pod has been assigned by Kubernetes.      | `true`                                           |
+| `service.annotations`                 | Kubernetes service annotations                                                                                                | `{prometheus.io/scrape: "true"}`                 |
+| `serviceAccount.create`               | Specifies whether a service account should be created.                                                                        | `true`                                           |
+| `serviceAccount.name`                 | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                                  |
+| `serviceAccount.imagePullSecrets`     | Specify image pull secrets                                                                                                    | `[]`                                             |
+| `securityContext`                     | SecurityContext                                                                                                               | See values.yaml                                  |
+| `affinity`                            | A group of affinity scheduling rules for pod assignment                                                                       | `{}`                                             |
+| `nodeSelector`                        | Node labels for pod assignment                                                                                                | `{}`                                             |
+| `tolerations`                         | List of node taints to tolerate                                                                                               | `- effect: NoSchedule operator: Exists`          |
+| `priorityClassName`                   | Name of Priority Class to assign pods                                                                                         | `nil`                                            |
+| `endpoints`                           | list of addresses that have node exporter deployed outside of the cluster                                                     | `[]`                                             |
+| `hostNetwork`                         | Whether to expose the service to the host network                                                                             | `true`                                           |
+| `prometheus.monitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                                                           | `false`                                          |
+| `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                         | `{}`                                             |
+| `prometheus.monitor.namespace`        | namespace where servicemonitor resource should be created                                                                     | `the same namespace as prometheus node exporter` |
+| `prometheus.monitor.relabelings`      | Relabelings that should be applied on the ServerMonitor                                                                       | `{}` |
+| `prometheus.monitor.scrapeTimeout`    | Timeout after which the scrape is ended                                                                                       | `10s`                                            |
+| `configmaps`                          | Allow mounting additional configmaps.                                                                                         | `[]`                                             |
+| `namespaceOverride`                   | Override the deployment namespace                                                                                             | `""` (`Release.Namespace`)                       |
+| `updateStrategy`                      | Configure a custom update strategy for the daemonset                                                                          | `Rolling update with 1 max unavailable`          |
+| `sidecars`               | Additional containers for export metrics to text file     | `[]`           |  |
+| `sidecarVolumeMount`               | Volume for sidecar containers     | `[]`           |  |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+  --set serviceAccount.name=node-exporter  \
+    stable/prometheus-node-exporter
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml stable/prometheus-node-exporter
+```

--- a/contents/Node-Exporter/helm-chart/ci/port-values.yaml
+++ b/contents/Node-Exporter/helm-chart/ci/port-values.yaml
@@ -1,0 +1,3 @@
+service:
+  targetPort: 9102
+  port: 9102

--- a/contents/Node-Exporter/helm-chart/templates/NOTES.txt
+++ b/contents/Node-Exporter/helm-chart/templates/NOTES.txt
@@ -1,0 +1,17 @@
+DEPRECATED and moved to <https://github.com/prometheus-community/helm-charts>
+
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ template "prometheus-node-exporter.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-node-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ template "prometheus-node-exporter.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "prometheus-node-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ template "prometheus-node-exporter.namespace" . }} {{ template "prometheus-node-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ template "prometheus-node-exporter.namespace" . }} -l "app={{ template "prometheus-node-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:9100 to use your application"
+  kubectl port-forward --namespace {{ template "prometheus-node-exporter.namespace" . }} $POD_NAME 9100
+{{- end }}

--- a/contents/Node-Exporter/helm-chart/templates/_helpers.tpl
+++ b/contents/Node-Exporter/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-node-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-node-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "prometheus-node-exporter.labels" }}
+app: {{ template "prometheus-node-exporter.name" . }}
+heritage: {{.Release.Service }}
+release: {{.Release.Name }}
+chart: {{ template "prometheus-node-exporter.chart" . }}
+{{- if .Values.podLabels}}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-node-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-node-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "prometheus-node-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "prometheus-node-exporter.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/contents/Node-Exporter/helm-chart/templates/daemonset.yaml
+++ b/contents/Node-Exporter/helm-chart/templates/daemonset.yaml
@@ -1,0 +1,151 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-node-exporter.name" . }}
+      release: {{ .Release.Name }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels: {{ include "prometheus-node-exporter.labels" . | indent 8 }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+      {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+{{- if and .Values.rbac.create .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "prometheus-node-exporter.serviceAccountName" . }}
+{{- end }}
+{{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+{{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
+      containers:
+        - name: node-exporter
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --web.listen-address=$(HOST_IP):{{ .Values.service.port }}
+{{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 12 }}
+{{- end }}
+          env:
+          - name: HOST_IP
+            {{- if .Values.service.listenOnAllInterfaces }}
+            value: 0.0.0.0
+            {{- else }}
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.port }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.port }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly:  true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            {{- if .Values.extraHostVolumeMounts }}
+            {{- range $_, $mount := .Values.extraHostVolumeMounts }}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+              readOnly: {{ $mount.readOnly }}
+            {{- if $mount.mountPropagation }}
+              mountPropagation: {{ $mount.mountPropagation }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.sidecarVolumeMount }}
+            {{- range $_, $mount := .Values.sidecarVolumeMount }}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- if .Values.configmaps }}
+            {{- range $_, $mount := .Values.configmaps }}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+            {{- end }}
+            {{- end }}
+{{- if .Values.sidecars }}
+{{ toYaml .Values.sidecars | indent 8 }}
+          {{- if .Values.sidecarVolumeMount }}
+          volumeMounts:
+            {{- range $_, $mount := .Values.sidecarVolumeMount }}
+            - name: {{ $mount.name }}
+              mountPath: {{ $mount.mountPath }}
+              readOnly: {{ $mount.readOnly }}
+            {{- end }}
+          {{- end }}
+{{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      hostPID: true
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        {{- if .Values.extraHostVolumeMounts }}
+        {{- range $_, $mount := .Values.extraHostVolumeMounts }}
+        - name: {{ $mount.name }}
+          hostPath:
+            path: {{ $mount.hostPath }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.sidecarVolumeMount }}
+        {{- range $_, $mount := .Values.sidecarVolumeMount }}
+        - name: {{ $mount.name }}
+          emptyDir:
+            medium: Memory
+        {{- end }}
+        {{- end }}
+        {{- if .Values.configmaps }}
+        {{- range $_, $mount := .Values.configmaps }}
+        - name: {{ $mount.name }}
+          configMap:
+            name: {{ $mount.name }}
+        {{- end }}
+        {{- end }}

--- a/contents/Node-Exporter/helm-chart/templates/endpoints.yaml
+++ b/contents/Node-Exporter/helm-chart/templates/endpoints.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.endpoints }}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+  labels:
+{{ include "prometheus-node-exporter.labels" . | indent 4 }}
+subsets:
+  - addresses:
+      {{- range .Values.endpoints }}
+      - ip: {{ . }}
+      {{- end }}
+    ports:
+      - name: metrics
+        port: 9100
+        protocol: TCP
+{{- end }}

--- a/contents/Node-Exporter/helm-chart/templates/monitor.yaml
+++ b/contents/Node-Exporter/helm-chart/templates/monitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.prometheus.monitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+  {{- if .Values.prometheus.monitor.additionalLabels }}
+{{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-node-exporter.name" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+    - port: metrics
+      {{- if .Values.prometheus.monitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.prometheus.monitor.scrapeTimeout }}
+      {{- end }}
+{{- if .Values.prometheus.monitor.relabelings }}
+      relabelings:
+{{ toYaml .Values.prometheus.monitor.relabelings | indent 6 }}
+{{- end }}
+{{- end }}

--- a/contents/Node-Exporter/helm-chart/templates/psp-clusterrole.yaml
+++ b/contents/Node-Exporter/helm-chart/templates/psp-clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: psp-{{ template "prometheus-node-exporter.fullname" . }}
+  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "prometheus-node-exporter.fullname" . }}
+{{- end }}
+{{- end }}

--- a/contents/Node-Exporter/helm-chart/templates/psp-clusterrolebinding.yaml
+++ b/contents/Node-Exporter/helm-chart/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: psp-{{ template "prometheus-node-exporter.fullname" . }}
+  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp-{{ template "prometheus-node-exporter.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "prometheus-node-exporter.fullname" . }}
+    namespace: {{ template "prometheus-node-exporter.namespace" . }}
+{{- end }}
+{{- end }}

--- a/contents/Node-Exporter/helm-chart/templates/psp.yaml
+++ b/contents/Node-Exporter/helm-chart/templates/psp.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.rbac.create }}
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  # allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  #requiredDropCapabilities:
+  #  - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+    - 'hostPath'
+  hostNetwork: true
+  hostIPC: false
+  hostPID: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  runAsUser:
+    # Permits the container to run with root privileges as well.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}
+{{- end }}

--- a/contents/Node-Exporter/helm-chart/templates/service.yaml
+++ b/contents/Node-Exporter/helm-chart/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "prometheus-node-exporter.fullname" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+  labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+    {{- if ( and (eq .Values.service.type "NodePort" ) (not (empty .Values.service.nodePort)) ) }}
+      nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: metrics
+  selector:
+    app: {{ template "prometheus-node-exporter.name" . }}
+    release: {{ .Release.Name }}

--- a/contents/Node-Exporter/helm-chart/templates/serviceaccount.yaml
+++ b/contents/Node-Exporter/helm-chart/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "prometheus-node-exporter.serviceAccountName" . }}
+  namespace: {{ template "prometheus-node-exporter.namespace" . }}
+  labels:
+    app: {{ template "prometheus-node-exporter.name" . }}
+    chart: {{ template "prometheus-node-exporter.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+imagePullSecrets:
+{{ toYaml .Values.serviceAccount.imagePullSecrets | indent 2 }}
+{{- end -}}
+{{- end -}}

--- a/contents/Node-Exporter/helm-chart/values.yaml
+++ b/contents/Node-Exporter/helm-chart/values.yaml
@@ -1,0 +1,141 @@
+# Default values for prometheus-node-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: quay.io/prometheus/node-exporter
+  tag: v1.0.1
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 9100
+  targetPort: 9100
+  nodePort:
+  listenOnAllInterfaces: true
+  annotations:
+    prometheus.io/scrape: "true"
+
+prometheus:
+  monitor:
+    enabled: false
+    additionalLabels: {}
+    namespace: ""
+
+    relabelings: []
+    scrapeTimeout: 10s
+
+## Customize the updateStrategy if set
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 200m
+  #   memory: 50Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 30Mi
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  imagePullSecrets: []
+
+securityContext:
+  fsGroup: 65534
+  runAsGroup: 65534
+  runAsNonRoot: true
+  runAsUser: 65534
+
+rbac:
+  ## If true, create & use RBAC resources
+  ##
+  create: true
+  ## If true, create & use Pod Security Policy resources
+  ## https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  pspEnabled: true
+
+# for deployments that have node_exporter deployed outside of the cluster, list
+# their addresses here
+endpoints: []
+
+# Expose the service to the host network
+hostNetwork: true
+
+## Assign a group of affinity scheduling rules
+##
+affinity: {}
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#         - matchFields:
+#             - key: metadata.name
+#               operator: In
+#               values:
+#                 - target-host-name
+
+# Annotations to be added to node exporter pods
+podAnnotations: {}
+
+# Extra labels to be added to node exporter pods
+podLabels: {}
+
+## Assign a nodeSelector if operating a hybrid cluster
+##
+nodeSelector: {}
+#   beta.kubernetes.io/arch: amd64
+#   beta.kubernetes.io/os: linux
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists
+
+## Assign a PriorityClassName to pods if set
+# priorityClassName: ""
+
+## Additional container arguments
+##
+extraArgs: []
+#   - --collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v)d[a-z]|nvme\\d+n\\d+p)\\d+$
+#   - --collector.textfile.directory=/run/prometheus
+
+## Additional mounts from the host
+##
+extraHostVolumeMounts: []
+#  - name: <mountName>
+#    hostPath: <hostPath>
+#    mountPath: <mountPath>
+#    readOnly: true|false
+#    mountPropagation: None|HostToContainer|Bidirectional
+
+## Additional configmaps to be mounted.
+##
+configmaps: []
+# - name: <configMapName>
+#   mountPath: <mountPath>
+
+## Override the deployment namespace
+##
+namespaceOverride: ""
+
+## Additional containers for export metrics to text file
+##
+sidecars: []
+##  - name: nvidia-dcgm-exporter
+##    image: nvidia/dcgm-exporter:1.4.3
+
+## Volume for sidecar containers
+##
+sidecarVolumeMount: []
+##  - name: collector-textfiles
+##    mountPath: /run/prometheus
+##    readOnly: false


### PR DESCRIPTION
- adding Node Exporter helm chart content into `contents/Node-Exporter/helm-chart`
- helm-chart contents from [prometheus-node-exporter](https://github.com/helm/charts/tree/master/stable/prometheus-node-exporter)