### PR TITLE
[CI/CD] add github action file for building and publishing docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Build and Publish Docker Container
+on:
+  push:
+    tags: [ 'fe*.*.*', 'api*.*.*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & Push Docker Image (FrontEnd)
+        if : ${{ startsWith(steps.tag.outputs.tag, 'fe') }}
+        run: |
+          docker build -t ${{ secrets.DOCKERHUB_FRONTEND_REPO }}:release-${{ steps.tag.outputs.tag }} ./ --no-cache
+          docker tag ${{ secrets.DOCKERHUB_FRONTEND_REPO }}:release-${{ steps.tag.outputs.tag }} ${{ secrets.DOCKERHUB_FRONTEND_REPO }}:latest
+          docker push ${{ secrets.DOCKERHUB_FRONTEND_REPO }}:release-${{ steps.tag.outputs.tag }}
+          docker push ${{ secrets.DOCKERHUB_FRONTEND_REPO }}:latest
+
+      - name: Build & Push Docker Image (BackEnd)
+        if : ${{ startsWith(steps.tag.outputs.tag, 'api') }}
+        run: |
+          cd api
+          docker build -t ${{ secrets.DOCKERHUB_BACKEND_REPO }}:release-${{ steps.tag.outputs.tag }} ./ --no-cache
+          docker tag ${{ secrets.DOCKERHUB_BACKEND_REPO }}:release-${{ steps.tag.outputs.tag }} ${{ secrets.DOCKERHUB_BACKEND_REPO }}:latest
+          docker push ${{ secrets.DOCKERHUB_BACKEND_REPO }}:release-${{ steps.tag.outputs.tag }}
+          docker push ${{ secrets.DOCKERHUB_BACKEND_REPO }}:latest


### PR DESCRIPTION
# Description
- add github action file(`.github/workflows/main.yml`) for building and publishing Exporterhub docker images 

# Details
- github worflow triggers when `fe*.*.*` or `api*.*.*` tag is added
  - tag pattern `fe*.*.*`: build frontend image and publish
  - tag pattern `api*.*.*`: build backend image and publish
- requires secrets for repository (can be set with github repository settings, see [Encrypted secrets
](https://docs.github.com/en/actions/reference/encrypted-secrets))
  - DOCKERHUB_USERNAME: docker hub username
  - DOCKERHUB_TOKEN: docker hub access token (see [Managing access tokens](https://docs.docker.com/docker-hub/access-tokens/))
  - DOCKERHUB_FRONTEND_REPO: Exporterhub frontend docker hub repository (ex. `nexclipper/exporterhub`)
  - DOCKERHUB_BACKEND_REPO: Exporterhub backend docker hub repository (ex. `nexclipper/exporterhub-api
`
- also  adding `latest` tag when publishing docker image