### PR TITLE
Add Prometheus Kafka Exporter helm chart contents

### DIFF
--- a/contents/Kafka-Exporter/helm-chart/Chart.yaml
+++ b/contents/Kafka-Exporter/helm-chart/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+appVersion: "v1.3.1"
+description: A Helm chart to export the metrics from Kafka in Prometheus format using the kafka-exporter from https://github.com/danielqsj/kafka_exporter
+name: prometheus-kafka-exporter
+home: https://github.com/danielqsj/kafka_exporter
+version: 1.2.0
+sources:
+  - https://gkarthiks.github.io/helm-charts/charts/prometheus-kafka-exporter
+keywords:
+  - prometheus
+  - kafka
+maintainers:
+  - name: gkarthiks
+    email: github.gkarthiks@gmail.com
+  - name: golgoth31
+    email: golgoth31@notrenet.com
+engine: gotpl
+annotations:
+  "artifacthub.io/links": |
+    - name: Chart Source
+      url: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-kafka-exporter
+dependencies:
+- name: kafka
+  version: "12.6.3"
+  repository: https://charts.bitnami.com/bitnami
+  condition: kafka.enabled

--- a/contents/Kafka-Exporter/helm-chart/README.md
+++ b/contents/Kafka-Exporter/helm-chart/README.md
@@ -1,0 +1,69 @@
+# prometheus-kafka-exporter
+
+A Prometheus exporter for [Apacher Kafka](https://kafka.apache.org/) metrics.
+
+This chart bootstraps a [Kafka Exporter](https://github.com/danielqsj/kafka_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+
+## Prerequisites
+
+- Kubernetes 1.8+ with Beta APIs enabled
+
+## Get Repo Info
+
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+
+## Install Chart
+
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-kafka-exporter
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-kafka-exporter
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-kafka-exporter/values.yaml), or run these configuration commands:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-kafka-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-kafka-exporter
+```

--- a/contents/Kafka-Exporter/helm-chart/templates/NOTES.txt
+++ b/contents/Kafka-Exporter/helm-chart/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-kafka-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "prometheus-kafka-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus-kafka-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-kafka-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/contents/Kafka-Exporter/helm-chart/templates/_helpers.tpl
+++ b/contents/Kafka-Exporter/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-kafka-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-kafka-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-kafka-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-kafka-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "prometheus-kafka-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for rbac.
+*/}}
+{{- define "rbac.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+{{- print "rbac.authorization.k8s.io/v1" -}}
+{{- else -}}
+{{- print "rbac.authorization.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}} 

--- a/contents/Kafka-Exporter/helm-chart/templates/deployment.yaml
+++ b/contents/Kafka-Exporter/helm-chart/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "prometheus-kafka-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-kafka-exporter.name" . }}
+    chart: {{ template "prometheus-kafka-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-kafka-exporter.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+{{ toYaml .Values.annotations | indent 8 }}
+      labels:
+        app: {{ template "prometheus-kafka-exporter.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "prometheus-kafka-exporter.serviceAccountName" . }}
+      containers:
+        - args:
+            - '--log.level={{ .Values.logLevel }}'
+          {{- if .Values.sarama.logEnabled }}
+            - '--log.enable-sarama'
+          {{- end }}
+          {{- range $server := .Values.kafkaServer }}
+            - '--kafka.server={{ $server }}'
+          {{- end }}
+          {{- if .Values.kafkaBrokerVersion }}
+            - '--kafka.version={{ .Values.kafkaBrokerVersion }}'
+          {{- end }}
+          {{- if .Values.tls.enabled }}
+            - '--tls.enabled'
+            - '--tls.ca-file={{ .Values.tls.mountPath }}/ca.crt'
+            - '--tls.cert-file={{ .Values.tls.mountPath }}/tls.crt'
+            - '--tls.key-file={{ .Values.tls.mountPath }}/tls.key'
+          {{- if .Values.tls.insecureSkipVerify }}
+            - '--tls.insecure-skip-tls-verify'
+          {{- end }}
+          {{- end }}
+          {{- if .Values.extraArgs }}
+          {{- range .Values.extraArgs  }}
+            - {{ . }}
+          {{- end }}
+          {{- end }}
+          env:
+{{- toYaml .Values.env | trim | nindent 12 }}
+          name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: exporter-port
+              containerPort: 9308
+              protocol: TCP
+{{- if .Values.liveness.enabled }}
+          livenessProbe:
+{{- toYaml .Values.liveness.probe | trim | nindent 12 }}
+{{- end }}
+{{- if .Values.readiness.enabled }}
+          readinessProbe:
+{{- toYaml .Values.readiness.probe | trim | nindent 12 }}
+{{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.tls.enabled }}
+          volumeMounts:
+          - mountPath: {{ .Values.tls.mountPath }}
+            name: kafka-certs
+            readOnly: true
+          {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      {{- if .Values.tls.enabled }}
+      volumes:
+      - name: kafka-certs
+        secret:
+          secretName: {{ .Values.tls.secretName }}
+    {{- end }}

--- a/contents/Kafka-Exporter/helm-chart/templates/podsecuritypolicy.yaml
+++ b/contents/Kafka-Exporter/helm-chart/templates/podsecuritypolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "prometheus-kafka-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-kafka-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/contents/Kafka-Exporter/helm-chart/templates/role.yaml
+++ b/contents/Kafka-Exporter/helm-chart/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ template "prometheus-kafka-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-kafka-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.rbac.pspEnabled }}
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ template "prometheus-kafka-exporter.fullname" . }}]
+{{- end }}
+{{- end }}

--- a/contents/Kafka-Exporter/helm-chart/templates/rolebinding.yaml
+++ b/contents/Kafka-Exporter/helm-chart/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create -}}
+apiVersion: {{ template "rbac.apiVersion" . }}
+kind: RoleBinding
+metadata:
+  name: {{ template "prometheus-kafka-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-kafka-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "prometheus-kafka-exporter.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-kafka-exporter.serviceAccountName" . }}
+{{- end -}}

--- a/contents/Kafka-Exporter/helm-chart/templates/service.yaml
+++ b/contents/Kafka-Exporter/helm-chart/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "prometheus-kafka-exporter.fullname" . }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+  labels:
+    app: {{ template "prometheus-kafka-exporter.name" . }}
+    chart: {{ template "prometheus-kafka-exporter.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: exporter-port
+      protocol: TCP
+      name: exporter-port
+  selector:
+    app: {{ template "prometheus-kafka-exporter.name" . }}
+    release: {{ .Release.Name }}

--- a/contents/Kafka-Exporter/helm-chart/templates/serviceaccount.yaml
+++ b/contents/Kafka-Exporter/helm-chart/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "prometheus-kafka-exporter.serviceAccountName" . }}
+  labels:
+    app: {{ template "prometheus-kafka-exporter.name" . }}
+    chart: {{ template "prometheus-kafka-exporter.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end -}}

--- a/contents/Kafka-Exporter/helm-chart/templates/servicemonitor.yaml
+++ b/contents/Kafka-Exporter/helm-chart/templates/servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prometheus-kafka-exporter.fullname" . }}
+  {{- if .Values.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "prometheus-kafka-exporter.name" . }}
+    helm.sh/chart: {{ include "prometheus-kafka-exporter.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.prometheus.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.prometheus.serviceMonitor.additionalLabels | indent 4 -}}
+    {{- end }}
+spec:
+  jobLabel: jobLabel
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-kafka-exporter.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: exporter-port
+    interval: {{ .Values.prometheus.serviceMonitor.interval }}
+    {{- if .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+{{- end }}

--- a/contents/Kafka-Exporter/helm-chart/values.yaml
+++ b/contents/Kafka-Exporter/helm-chart/values.yaml
@@ -1,0 +1,107 @@
+image:
+  repository: danielqsj/kafka-exporter
+  tag: v1.3.1
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+kafkaServer:
+  - kafka-server:9092
+
+# Specifies broker version to use, leave empty for default
+kafkaBrokerVersion:
+
+# Valid levels: [debug, info, warn, error, fatal]
+logLevel: info
+
+# Sarama logging
+sarama:
+  logEnabled: false
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  # Specifies whether a PodSecurityPolicy should be created
+  pspEnabled: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+env: []
+
+# List of additional cli arguments to configure kafka-exporter
+# for example: --log.enable-sarama, --log.level=debug, etc.
+# all the possible args can be found here: https://github.com/danielqsj/kafka_exporter#flags
+extraArgs: []
+
+service:
+  type: ClusterIP
+  port: 9308
+  annotations: {}
+
+liveness:
+  enabled: false
+  probe:
+    httpGet:
+      path: /
+      port: exporter-port
+
+readiness:
+  enabled: false
+  probe:
+    httpGet:
+      path: /
+      port: exporter-port
+
+prometheus:
+  serviceMonitor:
+    enabled: false
+    namespace: monitoring
+    interval: "30s"
+    # If serviceMonitor is enabled and you want prometheus to automatically register
+    # target using serviceMonitor, add additionalLabels with prometheus release name
+    # e.g. If you have deployed kube-prometheus-stack with release name kube-prometheus
+    # then additionalLabels will be
+    # additionalLabels:
+    #   release: kube-prometheus
+    additionalLabels: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+annotations: {}
+
+tolerations: []
+
+affinity: {}
+
+# this allows the usage of tls connection to your kafka cluster based on a secret in tls format
+# mandatory keys:
+# ca.crt
+# tls.crt
+# tls.key
+tls:
+  enabled: false
+  insecureSkipVerify: false
+  # mountPath: /secret/certs
+  # secretName: <name of an existing secret>
+
+# If enabled Kafka dependency chart will be used.
+# This is only needed for the CI job so it should always be disabled.
+kafka:
+  enabled: false


### PR DESCRIPTION
## Specify project
`contents`

## Description
Add `Prometheus Kafka Exporter` helm chart contents

## Details

- [x] Add Kafka Exporter helm chart content into `contents/Kafka-Exporter/helm-chart`
- [x] `helm-chart` contents are from [prometheus-kafka-exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-kafka-exporter)
