### PR TITLE
add description meta tag for SEO

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="assets/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="description" content="ExporterHub.io is an application for the Prometheus Exporters community. ExporterHub.io is not just a curated list, but also provides exporter installation guide, alert rule configuration, and dashboard configuration." />
 		<link rel="preconnect" href="https://fonts.gstatic.com" />
 		<link
 			href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500&display=swap"


### PR DESCRIPTION
- closes #126 
- add `<meta>` tag with description for SEO
- description  originated from [README.md](https://github.com/NexClipper/exporterhub.io/blob/main/README.md)