### PR TITLE
Add Veeam Backup & Replication exporter to Storage exporters

### DIFF
--- a/api/exporter_list.csv
+++ b/api/exporter_list.csv
@@ -40,3 +40,4 @@ dnsbl-exporter,dnsbl-exporter,https://github.com/Luzilla/dnsbl_exporter,0,Monito
 Query exporter,query-exporter,https://github.com/go-gywn/query-exporter,0,Database,
 Elasticsearch Exporter,Elasticsearch Exporter,https://github.com/prometheus-community/elasticsearch_exporter,0,Database,
 MongoDB,MongoDB Exporter,https://github.com/percona/mongodb_exporter,0,Database,
+Veeam,Veeam Backup Exporter,https://github.com/negatic/veeambackup-exporter,0,Storage,


### PR DESCRIPTION
## Summary

Add a Prometheus exporter for Veeam Backup & Replication to the Storage exporters section.

## Exporter

Name: Veeam Backup & Replication exporter

Repository:
https://github.com/negatic/veeambackup-exporter

## Description

This exporter exposes metrics from Veeam Backup & Replication, including backup job status, backup session results, repository capacity and utilization, replication status, and other operational metrics for monitoring Veeam environments with Prometheus and Grafana.

## Why

Veeam is widely used for enterprise backup and disaster recovery workloads. Listing this exporter will help Prometheus users discover and monitor Veeam infrastructure using native Prometheus metrics.

## Checklist

- [x] Open source repository
- [x] Exporter exposes Prometheus metrics
- [x] Documentation included
- [x] Actively maintained